### PR TITLE
feat: add Flake8 using PEP8 python oficial

### DIFF
--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -35,6 +35,12 @@ jobs:
                --enable=deprecated \
                --fail-on=deprecated \
                api/ artesanato/
+               
+    - name: Verificar estilo PEP 8 com flake8
+      run: |
+        cd artesanato
+        pip install flake8
+        flake8 . --count --statistics
   
   test:
     runs-on: ubuntu-latest

--- a/artesanato/.flake8
+++ b/artesanato/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 100
+exclude = .git,__pycache__,venv,migrations
+ignore = E203, W503, E501
+per-file-ignores =
+    __init__.py: F401
+    tests/*: S101
+    */migrations/*: E501


### PR DESCRIPTION
O pipeline vai rodar com erro, pois o flake8 vai identificar que projeto tem várias coisas para adequar ao padrão PEP8.